### PR TITLE
Input parser specific for fasta quality files

### DIFF
--- a/cogent/parse/fasta.py
+++ b/cogent/parse/fasta.py
@@ -68,7 +68,37 @@ def MinimalFastaParser(infile, strict=True, \
         seq = ''.join(rec[1:])
 
         yield label, seq
+        
+def MinimalFastaQualityParser(infile, strict=True, \
+    label_to_name=str, finder=FastaFinder, quality_converter=str, \
+    is_label=None, label_characters='>'):
+    """Yields successive sequences from infile as (label, qual) tuples.
 
+    If strict is True (default), raises RecordError when label or seq missing.
+    """
+    
+    for rec in finder(infile):
+        #first line must be a label line
+        if not rec[0][0] in label_characters:
+            if strict:
+                raise RecordError, "Found Fasta record without label line: %s"%\
+                    rec
+            else:
+                continue
+        #record must have at least one sequence
+        if len(rec) < 2:
+            if strict:
+                raise RecordError, "Found label line without sequences: %s" % \
+                    rec
+            else:
+                continue
+            
+        label = rec[0][1:].strip()
+        label = label_to_name(label)
+        qual = ' '.join(rec[1:])
+        qual = quality_converter(qual)
+        yield label, qual
+        
 GdeFinder = LabeledRecordFinder(is_gde_label, ignore=is_blank) 
 
 def MinimalGdeParser(infile, strict=True, label_to_name=str):

--- a/cogent/parse/fasta.py
+++ b/cogent/parse/fasta.py
@@ -73,8 +73,10 @@ def MinimalFastaQualityParser(infile, strict=True, \
     label_to_name=str, finder=FastaFinder, quality_converter=str, \
     is_label=None, label_characters='>'):
     """Yields successive sequences from infile as (label, qual) tuples.
-
-    If strict is True (default), raises RecordError when label or seq missing.
+       infile: python file object representing a fasta file
+       strict: If strict is True (default), raises RecordError when label or seq missing.
+       label_to_name: function to transform the sequence identifier (default: str())
+       quality_converter: function to transform the quality string (default: str())
     """
     
     for rec in finder(infile):

--- a/tests/test_parse/test_fasta.py
+++ b/tests/test_parse/test_fasta.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Unit tests for FASTA and related parsers.
 """
-from cogent.parse.fasta import FastaParser, MinimalFastaParser, \
+from cogent.parse.fasta import FastaParser, MinimalFastaParser, MinimalFastaQualityParser, \
     NcbiFastaLabelParser, NcbiFastaParser, RichLabel, LabelParser, GroupFastaParser
 from cogent.core.sequence import DnaSequence, Sequence, ProteinSequence as Protein
 from cogent.core.info import Info
@@ -34,6 +34,8 @@ class GenericFastaTest(TestCase):
         self.twogood='>123\n\n> \t abc  \t \ncag\ngac\n>456\nc\ng'.split('\n')
         self.oneX='>123\nX\n> \t abc  \t \ncag\ngac\n>456\nc\ng'.split('\n')
         self.nolabels = 'GJ>DSJGSJDF\nSFHKLDFS>jkfs\n'.split('\n')
+        self.qualityOneline = '>abc\n0 30 14 10\n'.split('\n')
+        self.qualityTwoline = '>abc\n0 30 14 10\n13 28 27'.split('\n')
         self.empty = []
  
 class MinimalFastaParserTests(GenericFastaTest):
@@ -85,6 +87,20 @@ class MinimalFastaParserTests(GenericFastaTest):
         self.assertEqual(a, ('abc', 'caggac'))
         self.assertEqual(b, ('456', 'cg'))
 
+class FastaQualityParserTests(GenericFastaTest):
+    
+    def test_qualityOneline(self):
+        f = list(MinimalFastaQualityParser(self.qualityOneline))
+        self.assertEqual(len(f), 1)
+        a = f[0]
+        self.assertEqual(a, ('abc', '0 30 14 10')) 
+    
+    def test_qualityTwoline(self):
+       f = list(MinimalFastaQualityParser(self.qualityTwoline))
+       self.assertEqual(len(f), 1)
+       a = f[0]
+       self.assertEqual(a, ('abc', '0 30 14 10 13 28 27'))
+    
 class FastaParserTests(GenericFastaTest):
     """Tests of FastaParser: returns sequence objects."""
        


### PR DESCRIPTION
I noticed a bug in `cogent.parse.fasta.MinimalFastaParser` when parsing an old style quality file that were split across multiple lines such as:

>identifier
10 12 13 14 15 20 30
34 41 21 30 12 10 11

what occurs is that the last qual score of a line and the first qual score of the next line get merged together such that the output looks like the following:

>identifier
10 12 13 14 15 20 **3034** 41 21 30 12 10 11

to overcome this I've added in a new parser into `cogent/parse/fasta.py` specific to fasta quality files that returns the desired output
