### PR TITLE
Fixed an ApplicationError when using a different working directory with cd_hit app controller

### DIFF
--- a/cogent/app/cd_hit.py
+++ b/cogent/app/cd_hit.py
@@ -3,6 +3,7 @@
 
 import shutil
 from os import remove
+from os.path import join as path_join
 from cogent.app.parameters import ValuedParameter
 from cogent.app.util import CommandLineApplication, ResultPath,\
         get_tmp_filename
@@ -177,14 +178,15 @@ class CD_HIT(CommandLineApplication):
     def _get_seqs_outfile(self):
         """Returns the absolute path to the seqs outfile"""
         if self.Parameters['-o'].isOn():
-            return self.Parameters['-o'].Value
+            return path_join(self.WorkingDir, self.Parameters['-o'].Value)
         else:
             raise ValueError, "No output file specified"
 
     def _get_clstr_outfile(self):
         """Returns the absolute path to the clstr outfile"""
         if self.Parameters['-o'].isOn():
-            return ''.join([self.Parameters['-o'].Value, '.clstr'])
+            return path_join(self.WorkingDir,\
+                    ''.join([self.Parameters['-o'].Value, '.clstr']))
         else:
             raise ValueError, "No output file specified"
 


### PR DESCRIPTION
When using the CD-HIT application controller there would be an
ApplicationError thrown from the CommandLineAppResult constructor
if the WorkingDir property was set.  

For example the following code would throw the error:

``` python
>>> from cogent.app.cd_hit import CD_HIT_EST
>>> cdhit = CD_HIT_EST(WorkingDir='pipeline/16Smock1_EBPRPhage_IMBMiSeqDec2012/root/Bacteria/Actinobacteria/Actinobacteria/Actinomycetales/Brevibacteriaceae/Brevibacterium/aureum')
>>> cdhit.Parameters['-i'].on('reads.fa')
>>> cdhit.Parameters['-o'].on('cdhitout.fa')
>>> ret = cdhit()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/sw/PyCogent/connors-dev/lib/python2.7/site-packages/cogent/app/util.py", line 274, in __call__
    out,err,exit_status,self._get_result_paths(data))
  File "/sw/PyCogent/connors-dev/lib/python2.7/site-packages/cogent/app/util.py", line 291, in _handle_app_result_build_failure
    raise ApplicationError, "Error constructing CommandLineAppResult."
cogent.app.util.ApplicationError: Error constructing CommandLineAppResult.
```

however by cd'ing into the working directory first and then running the same thing you get the desired result

``` python
$ cd pipeline/16Smock1_EBPRPhage_IMBMiSeqDec2012/root/Bacteria/Actinobacteria/Actinobacteria/Actinomycetales/Brevibacteriaceae/Brevibacterium/aureum
python

>>> from cogent.app.cd_hit import CD_HIT_EST
>>> cdhit = CD_HIT_EST()
>>> cdhit.Parameters['-i'].on('reads.fa')
>>> cdhit.Parameters['-o'].on('cdhitout.fa')
>>> ret = cdhit()
>>> ret
{'FASTA': <open file 'cdhitout.fa', mode 'r' at 0x1735f60>, 'CLSTR': <open file 'cdhitout.fa.clstr', mode 'r' at 0x173e300>, 'ExitStatus': 0, 'StdErr': <open file '/tmp/tmpkKT57HHgAgnPevg22hgA.txt', mode 'r' at 0x17356f0>, 'StdOut': <open file '/tmp/tmpzMXcemSG2Ws3XNX0eLPF.txt', mode 'r' at 0x1731c90>}
```

The issue was resolved by joining the WorkingDir and the ouput file in `_get_seqs_outfile` and `_get_clstr_outfile`.
