### PR TITLE
fixed bug in setMaxTipTipDistance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,9 @@ Changes
 Bug Fixes
 ---------
 
+* Fixed bug in cogent.core.tree.PhyloNode.setMaxTipTipDistance where the
+  method was accidentally updating variables in place across the tree and 
+  producing incorrect results. Added a more explicit test as well.
 * Fixed bug in cogent.maths.stats.test.t_two_sample that returned a t-statistic
   with the wrong sign if the first distribution contained multiple values and
   the second distribution contained only a single value.

--- a/cogent/core/tree.py
+++ b/cogent/core/tree.py
@@ -1047,17 +1047,28 @@ class TreeNode(object):
             else:
                 if len(n.Children) == 1:
                     tip_a, tip_b = n.Children[0].MaxDistTips
+
+                    # avoid inplace ops...
+                    tip_a = tip_a[:]
+                    tip_b = tip_b[:]
+
                     tip_a[0] += n.Children[0].Length or 0.0
                     tip_b[0] += n.Children[0].Length or 0.0
                 else:
-                    tip_info = [(max(c.MaxDistTips), c) for c in n.Children]
+                    tip_info = [(max(c.MaxDistTips[:]), c) for c in n.Children]
                     dists = [i[0][0] for i in tip_info]
                     best_idx = argsort(dists)[-2:]
                     tip_a, child_a = tip_info[best_idx[0]]
                     tip_b, child_b = tip_info[best_idx[1]]
+                    
+                    # avoid inplace ops...
+                    tip_a = tip_a[:]
+                    tip_b = tip_b[:]
+
                     tip_a[0] += child_a.Length or 0.0
                     tip_b[0] += child_b.Length or 0.0
-                n.MaxDistTips = [tip_a, tip_b]
+                
+                n.MaxDistTips = [tip_a[:], tip_b[:]]
 
     def getMaxTipTipDistance(self):
         """Returns the max tip tip distance between any pair of tips

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1360,7 +1360,6 @@ class PhyloNodeTests(TestCase):
         self.assertEqual(tip_a[0] + tip_b[0], 10)
         self.assertEqual(sorted([tip_a[1],tip_b[1]]), ['g','h'])
 
-        print "******************"
         t_str = "((a:0.1,b:0.2)i1:0.3,(c:0.05,d:0.123)i2:0.08)root;"
         t = DndParser(t_str)
         t.setMaxTipTipDistance()

--- a/tests/test_core/test_tree.py
+++ b/tests/test_core/test_tree.py
@@ -1360,6 +1360,22 @@ class PhyloNodeTests(TestCase):
         self.assertEqual(tip_a[0] + tip_b[0], 10)
         self.assertEqual(sorted([tip_a[1],tip_b[1]]), ['g','h'])
 
+        print "******************"
+        t_str = "((a:0.1,b:0.2)i1:0.3,(c:0.05,d:0.123)i2:0.08)root;"
+        t = DndParser(t_str)
+        t.setMaxTipTipDistance()
+        self.assertEqual(t.MaxDistTips, [[0.203, 'd'], [0.5, 'b']])
+        self.assertEqual(t.Children[0].MaxDistTips, [[0.1, 'a'], [0.2, 'b']])
+        self.assertEqual(t.Children[1].MaxDistTips, [[0.05, 'c'], [0.123, 'd']])
+        self.assertEqual(t.Children[0].Children[0].MaxDistTips, 
+                        [[0.0, 'a'], [0.0, 'a']])
+        self.assertEqual(t.Children[0].Children[1].MaxDistTips, 
+                        [[0.0, 'b'], [0.0, 'b']])
+        self.assertEqual(t.Children[1].Children[0].MaxDistTips, 
+                        [[0.0, 'c'], [0.0, 'c']])
+        self.assertEqual(t.Children[1].Children[1].MaxDistTips, 
+                        [[0.0, 'd'], [0.0, 'd']])
+
     def test_maxTipTipDistance(self):
         """maxTipTipDistance returns the max dist between any pair of tips"""
         nodes, tree = self.TreeNode, self.TreeRoot


### PR DESCRIPTION
`PhyloNode.setMaxTipTIpDistance` was not actually being calculated correctly. Added a more explicit test, and corrected the method. Issue was due to unexpected in place modification to variables.
