### PR TITLE
A small bugfix enabling half-bounded optimisation to work as intended.

### DIFF
--- a/cogent/maths/optimisers.py
+++ b/cogent/maths/optimisers.py
@@ -128,11 +128,11 @@ def maximise(f, xinit, bounds=None, local=None, filename=None, interval=None,
         x = numpy.atleast_1d(x)
     
     if bounds is not None:
-        (upper, lower) = bounds
+        (lower, upper) = bounds
         if upper is not None or lower is not None:
             if upper is None: upper = numpy.inf
             if lower is None: lower = -numpy.inf
-            f = bounded_function(f, upper, lower)
+            f = bounded_function(f, lower, upper)
     try:
         fval = f(x)
     except (ArithmeticError, ParameterOutOfBoundsError), detail:


### PR DESCRIPTION
This fixes an obscure but simple bug, it is very unlikely anyone else has ever noticed it or ever would, but it is a bug and I can't knowingly leave it unfixed.  It is only encountered when using cogent.optimisers directly to minimise/maximise a function with the input(s) bound on only one side, eg: minimise(f, x, bounds=(0, None)).  
