### PR TITLE
have gamma return a float when x=2

### DIFF
--- a/cogent/maths/stats/special.py
+++ b/cogent/maths/stats/special.py
@@ -756,7 +756,7 @@ def Gamma(x):
         z /= x
         x += 1
     if x == 2:
-        return z
+        return float(z)
     x -= 2
     p = polevl(x, GP)
     q = polevl(x, GQ)


### PR DESCRIPTION
Issue was inconsistent return types. This doesn't actually completely cover it in the case that, for instance, a numpy type is sent in. I did not enumerate all of the paths through the code either. The issue came about when using `Gamma` to compute the PDF of the Gamma distribution. I was accidentally passing in mixed integers and floats, and realized that the return when x=2 was the same type as what was sent in; an integer in this case. This led to a divide by zero due to integer division.
