### PR TITLE
Fix error in Heip E index computation

### DIFF
--- a/cogent/maths/stats/alpha_diversity.py
+++ b/cogent/maths/stats/alpha_diversity.py
@@ -173,7 +173,7 @@ def mcintosh_e(counts):
 
 def heip_e(counts):
     """Heip's evenness measure: Heip & Engels 1974."""
-    return exp(shannon(counts, base=e)-1)/((counts!=0).sum()-1)
+    return (exp(shannon(counts, base=e))-1)/((counts!=0).sum()-1)
 
 def simpson_e(counts):
     """Simpson's evenness, from SDR-IV."""

--- a/tests/test_maths/test_stats/test_alpha_diversity.py
+++ b/tests/test_maths/test_stats/test_alpha_diversity.py
@@ -161,7 +161,7 @@ class diversity_tests(TestCase):
         """heip e should match hand-calculated value"""
         c = array([1,2,3,1])
         h = shannon(c, base=e)
-        expected = exp(h-1)/3
+        expected = (exp(h)-1)/3
         self.assertEqual(heip_e(c), expected)
 
     def test_simpson_e(self):


### PR DESCRIPTION
I believe that the computation of Heip's evenness index is wrong.
In Heip and Engels, J.mar.biol.Ass.UK 54:559-563 (1974) the formula is E = ((e^H) -1) / (S-1).
Instead, here it is computed as e^(H -1) / (S-1).

I noticed this while comparing the heip_e results obtained by Qiime vs. Mothur - which reports results consistent with my correction.
