### PR TITLE
BUG/DOC: test and fix for Canberra-Adkins

### DIFF
--- a/cogent/maths/distance_transform.py
+++ b/cogent/maths/distance_transform.py
@@ -1,40 +1,40 @@
 #!/usr/bin/env python
 """ matrix based distance metrics, and related coordinate transforms
-     
+
 functions to compute distance matrices row by row from abundance matrices,
 typically samples (rows) vs. species/OTU's (cols)
 
 DISTANCE FUNCTIONS
-For distance functions, the API resembles the following (but see function 
+For distance functions, the API resembles the following (but see function
 docstring for specifics):
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros *typically* returns 0 distance between them
     * negative values are only allowed for some distance metrics,
-    in these cases if strict==True, negative input values return a ValueError, 
+    in these cases if strict==True, negative input values return a ValueError,
     and if strict==False, errors or misleading return values may result
     * functions prefaced with "binary" consider only presense/absense in
     input data (qualitative rather than quantitative)
 
 TRANSFORM FUNCTIONS
 * For transform functions, very little error checking exists.  0/0 evals
-in transform fomulas will throw errors, and negative data will return 
+in transform fomulas will throw errors, and negative data will return
 spurious results or throw errors
 * The transform functions are as described in
     Legendre, P. and E. Gallagher. 2001.  Ecologically meaningful
     transformations for ordination of species data.  Oecologia: 129: 271-280.
 These and allow the use
-of ordination methods such as PCA and RDA, which are Euclidean-based, 
+of ordination methods such as PCA and RDA, which are Euclidean-based,
 for the analysis of community data, while circumventing the problems associated
 with the Euclidean distance. The matrix that is returned still has samples as
 rows and species as columns, but the values are transformed so that when
 programs such as PCA calculate euclidean distances on the matrix, chord,
 chisquare, 'species profile', or hellinger distances will result.
 
-EXAMPLE USAGE: 
+EXAMPLE USAGE:
     >from distance_transform import dist_euclidean
     >from numpy import array
 
@@ -45,17 +45,17 @@ EXAMPLE USAGE:
     >dists = dist_euclidean(abundance_data)
 
     >print dists
-    
+
     array([[  0.        ,   4.12310563,  19.02130385],
            [  4.12310563,   0.        ,  20.5915031 ],
            [ 19.02130385,  20.5915031 ,   0.        ]])
 
-    
+
 """
 from __future__ import division
 import numpy
 from numpy import (array, zeros, logical_and, logical_or, logical_xor, where,
-    mean, std, argsort, take, ravel, logical_not, shape, sqrt, abs, 
+    mean, std, argsort, take, ravel, logical_not, shape, sqrt, abs,
     sum, square, asmatrix, asarray, multiply, min, any, all, isfinite,
     nonzero, nan_to_num, geterr, seterr, isnan)
 
@@ -65,7 +65,7 @@ except ImportError:
     from numpy import rank
 
 # any, all from numpy override built in any, all, preventing:
-# ValueError: The truth value of an array with more than one element is 
+# ValueError: The truth value of an array with more than one element is
 # ambiguous. Use a.any() or a.all()
 
 from numpy.linalg import norm
@@ -73,7 +73,7 @@ from numpy.linalg import norm
 __author__ = "Justin Kuczynski"
 __copyright__ = "Copyright 2007-2016, The Cogent Project"
 __credits__ = ["Rob Knight", "Micah Hamady", "Justin Kuczynski",
-                    "Zongzhi Liu", "Catherine Lozupone", 
+                    "Zongzhi Liu", "Catherine Lozupone",
                     "Antonio Gonzalez Pena", "Greg Caporaso"]
 __license__ = "GPL"
 __version__ = "1.9"
@@ -82,7 +82,7 @@ __email__ = "justinak@gmail.com"
 __status__ = "Prototype"
 
 def _rankdata(a):
-    """ Ranks the data in a, dealing with ties appropritely.  First ravels 
+    """ Ranks the data in a, dealing with ties appropritely.  First ravels
     a.  Adapted from Gary Perlman's |Stat ranksort.
     private helper function
 
@@ -122,7 +122,7 @@ def trans_chisq(m):
     """perform a chi squared distance transformation on the rows of m
 
     transforms m to m' so that the euclidean dist between the rows of m' equals
-    the chi squared dist between the rows of m.    
+    the chi squared dist between the rows of m.
     Ref:
     Legendre, P. and E. Gallagher. 2001.  Ecologically meaningful
     transformations for ordination of species data.  Oecologia: 129: 271-280.
@@ -166,23 +166,23 @@ def trans_hellinger(m):
 
 def dist_bray_curtis(datamtx, strict=True):
     """ returns bray curtis distance (normalized manhattan distance) btw rows
-    
+
     dist(a,b) = manhattan distance / sum on i( (a_i + b_i) )
-    
+
     see for example:
     Faith et al. 1987
     Compositional dissimilarity as a robust measure of ecological distance
     Vegitatio
 
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -210,7 +210,7 @@ def dist_bray_curtis(datamtx, strict=True):
             r2 = datamtx[j,:]
             abs_v = float(sum(abs(r1 - r2)))
             v = sum(r1 + r2)
-            cur_d = 0.0 
+            cur_d = 0.0
             if v > 0:
                 cur_d = abs_v/v
 
@@ -221,22 +221,22 @@ dist_bray_curtis_faith = dist_bray_curtis
 
 def dist_bray_curtis_magurran(datamtx, strict=True):
     """ returns bray curtis distance (quantitative sorensen) btw rows
-    
+
     dist(a,b) = 2*sum on i( min( a_i, b_i)) / sum on i( (a_i + b_i) )
-    
+
     see for example:
     Magurran 2004
     Bray 1957
 
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -274,22 +274,22 @@ def dist_bray_curtis_magurran(datamtx, strict=True):
     return dists
 
 def dist_canberra(datamtx, strict=True):
-    """returns a row-row canberra dist matrix
-    
+    """returns a row-row canberra dist matrix in Adkins form
+
     see for example:
     Faith et al. 1987
     Compositional dissimilarity as a robust measure of ecological distance
     Vegitatio
 
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     * chisq dist normalizes by column sums - empty columns (all zeros) are
@@ -320,10 +320,10 @@ def dist_canberra(datamtx, strict=True):
             dist = 0.0
             net = abs( r1 - r2 ) / (r1 + r2)
 
+            num_nonzeros = ((r1 + r2) > 0).sum()
             net = nan_to_num(net)
-            num_nonzeros = nonzero(net)[0].size
             dists[i,j] = dists[j,i] = nan_to_num(net.sum()/num_nonzeros)
-            
+
     seterr(**oldstate)
     return dists
 
@@ -334,9 +334,9 @@ def dist_chisq(datamtx, strict=True):
     Faith et al. 1987
     Compositional dissimilarity as a robust measure of ecological distance
     Vegitatio
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -344,7 +344,7 @@ def dist_chisq(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     * chisq dist normalizes by column sums - empty columns (all zeros) are
@@ -394,18 +394,18 @@ def dist_chord(datamtx, strict=True):
     """returns a row-row chord dist matrix
 
     attributed to Orloci (with accent).  see Legendre 2001,
-    ecologically meaningful... 
-    
+    ecologically meaningful...
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * an all zero row compared with a not all zero row returns a distance of 1
-    * if strict==True, raises ValueError if any of the input data is 
+    * if strict==True, raises ValueError if any of the input data is
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a 2d matrix.  
+    * if strict==False, assumes input data is a 2d matrix.
     If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -442,16 +442,16 @@ def dist_chord(datamtx, strict=True):
 
 def dist_euclidean(datamtx, strict=True):
     """returns a row by row euclidean dist matrix
-    
+
     returns the euclidean norm of row1 - row2 for all rows in datamtx
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
-    * if strict==True, raises ValueError if any of the input data is 
+    * if strict==True, raises ValueError if any of the input data is
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a 2d matrix.  
+    * if strict==False, assumes input data is a 2d matrix.
     If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -482,23 +482,23 @@ def dist_euclidean(datamtx, strict=True):
 
 def dist_gower(datamtx, strict=True):
     """returns a row-row gower dist matrix
-    
+
     see for example, Faith et al., 1987
-    
-    
+
+
     * note that the comparison between any two rows is dependent on the entire
     data matrix, d_ij is a fn of all of datamtx, not just i,j
     * comparisons are between rows (samples)
     * any column containing identical data for all rows is ignored (this
     prevents a 0/0 error in the formula for gower distance
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a 2d matrix.  
+    * if strict==False, assumes input data is a 2d matrix.
     If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -534,9 +534,9 @@ def dist_gower(datamtx, strict=True):
 
 def dist_hellinger(datamtx, strict=True):
     """returns a row-row hellinger dist matrix
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -544,7 +544,7 @@ def dist_hellinger(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -583,13 +583,13 @@ def dist_hellinger(datamtx, strict=True):
 
 def dist_kulczynski(datamtx, strict=True):
     """ calculates the kulczynski distances between rows of a matrix
-    
+
     see for example Faith et al., composiitonal dissimilarity, 1987
     returns a distance of 1 between a row of zeros and a row with at least one
     nonzero element
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -597,7 +597,7 @@ def dist_kulczynski(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -642,15 +642,15 @@ def dist_manhattan(datamtx, strict=True):
 
     dist(a,b) = sum on i( abs(a_i - b_i) )
     negative values ok (but not tested)
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * if strict==True, raises ValueError if any of the input data is
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a 2d matrix.  
+    * if strict==False, assumes input data is a 2d matrix.
     If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -673,7 +673,7 @@ def dist_manhattan(datamtx, strict=True):
         r1 = datamtx[i] # cache here
         for j in range(i):
             dists[i,j] = dists[j,i] = sum(abs(r1 - datamtx[j]))
-            
+
     return dists
 
 def dist_abund_jaccard(datamtx, strict=True):
@@ -688,9 +688,9 @@ def dist_abund_jaccard(datamtx, strict=True):
     V = sum of relative abundances of shared species in b
 
     The Chao-Jaccard distance is 1 - J_abd
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -698,7 +698,7 @@ def dist_abund_jaccard(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -719,7 +719,7 @@ def dist_abund_jaccard(datamtx, strict=True):
     if numrows == 0 or numcols == 0:
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
-    
+
     rowsums = datamtx.sum(axis=1, dtype='float')
 
     for i in range(numrows):
@@ -753,9 +753,9 @@ def dist_morisita_horn(datamtx, strict=True):
     dist(a,b) = 1 - 2*sum(a_i * b_i) /( (d_a + d_b)* N_a * N_b )
 
     see book: magurran 2004 pg 246
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -763,7 +763,7 @@ def dist_morisita_horn(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -784,10 +784,10 @@ def dist_morisita_horn(datamtx, strict=True):
     if numrows == 0 or numcols == 0:
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
-    
+
     rowsums = datamtx.sum(axis=1, dtype='float')
     row_ds = (datamtx**2).sum(axis=1, dtype='float') # these are d_a, etc
-    
+
     for i in range(numrows):
         if row_ds[i] !=0.:
             row_ds[i] = row_ds[i] / rowsums[i]**2
@@ -815,19 +815,19 @@ def dist_morisita_horn(datamtx, strict=True):
 def dist_pearson(datamtx, strict=True):
     """ Calculates pearson distance (1-r) between rows
 
-    
+
     note that the literature sometimer refers to the pearson dissimilarity
     as (1 - r)/2 (e.g.: BC Blaxall et al. 2003: Differential Myocardial Gene
     Expression in the Development and Rescue of Murine Heart Failure)
-    
-    for pearson's r, see for example: Thirteen Ways to Look at the 
+
+    for pearson's r, see for example: Thirteen Ways to Look at the
     Correlation Coefficient by J rodgers, 1988
 
-    * distance varies between 0-2, inclusive.  
+    * distance varies between 0-2, inclusive.
     * Flat rows (all elements itentical) will return a distance of 1 relative
     to any non-flat row, and a distance of zero to another flat row
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -879,27 +879,27 @@ def dist_pearson(datamtx, strict=True):
             else:
                 bottom = sqrt(sum1 * sum2)
                 r = top/bottom
-                
+
             dists[i][j] = dists[j][i] = 1.0 - r
-            
+
     return dists
 
 def dist_soergel(datamtx, strict=True):
     """ Calculate soergel distance between rows of a matrix
-    
+
     see for example Evaluation of Distance Metrics..., Fechner 2004
     dist(a,b) = sum on i( abs(a_i - b_i) ) / sum on i( max(a_i, b_i) )
-    
+
     returns: a symmetric distance matrix, numrows X numrows
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -935,16 +935,16 @@ def dist_soergel(datamtx, strict=True):
 
 def dist_spearman_approx(datamtx, strict=True):
     """ Calculate spearman rank distance (1-r) using an approximation formula
-    
-    considers only rank order of elements in a row, averaging ties 
+
+    considers only rank order of elements in a row, averaging ties
     [19.2, 2.1, 0.03, 2.1] -> [3, 1.5, 0, 1.5]
     then performs dist(a,b) = 6 * sum(D^2) / (N*(N^2 - 1))
     where D is difference in rank of element i between row a and row b,
     N is the length of either row
-    
+
     * formula fails for < 2 columns, returns a zeros matrix
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -972,10 +972,10 @@ def dist_spearman_approx(datamtx, strict=True):
     if numrows == 0 or numcols == 0:
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
-    
+
     if numcols < 2:
         return dists # formula fails for < 2 elements per row
-    
+
     for i in range(numrows):
         r1 = datamtx[i,:]
         rank1 = _rankdata(r1)
@@ -985,15 +985,15 @@ def dist_spearman_approx(datamtx, strict=True):
             rankdiff = rank1 - rank2
             dsqsum = sum((rankdiff)**2)
             dist = 6*dsqsum / float(numcols*(numcols**2-1))
-            
+
             dists[i][j] = dists[j][i] = dist
     return dists
 
 def dist_specprof(datamtx, strict=True):
     """returns a row-row species profile distance matrix
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -1001,7 +1001,7 @@ def dist_specprof(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -1040,11 +1040,11 @@ def dist_specprof(datamtx, strict=True):
 
 def binary_dist_otu_gain(otumtx):
     """ Calculates number of new OTUs observed in sample A wrt sample B
-    
-        This is an non-phylogenetic distance matrix analagous to unifrac_g. 
+
+        This is an non-phylogenetic distance matrix analagous to unifrac_g.
         The number of OTUs gained in each sample is computed with respect to
         each other sample.
-    
+
     """
     result = []
     for i in otumtx:
@@ -1094,14 +1094,14 @@ def binary_dist_sorensen_dice(datamtx, strict=True):
     Dice dist = 1 - (2*c)/(a + b).
     also known as whittaker:
     whittaker = (a + b - c)/( 0.5*(a+b) ) - 1
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
-    * negative input values are not allowed - will return nonsensical results 
+    * negative input values are not allowed - will return nonsensical results
     and/or throw errors
     """
     datamtx = datamtx.astype(bool)
@@ -1124,7 +1124,7 @@ def binary_dist_sorensen_dice(datamtx, strict=True):
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
     rowsums = datamtx.sum(axis=1)
-    
+
     for i in range(numrows):
         row1 = datamtx[i]
         for j in range(i):
@@ -1148,26 +1148,26 @@ def binary_dist_euclidean(datamtx, strict=True):
 def binary_dist_hamming(datamtx, strict=True):
     """Calculates hamming distance btw rows, returning distance matrix.
 
-    Note: Treats array as bool. 
+    Note: Treats array as bool.
     see for example wikipedia hamming_distance, 20 jan 2008
 
     hamming is identical to binary manhattan distance
 
-    Binary hamming: 
+    Binary hamming:
     a = num 1's in a
     b = num 1's in b
     c = num that are 1's in both a and b
     hamm = a + b - 2c
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -1191,7 +1191,7 @@ def binary_dist_hamming(datamtx, strict=True):
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
     rowsums = datamtx.sum(axis=1)
-    
+
     for i in range(numrows):
         first = datamtx[i]
         a = rowsums[i]
@@ -1202,12 +1202,12 @@ def binary_dist_hamming(datamtx, strict=True):
             dist = a + b - (2.0*c)
             dists[i][j] = dists[j][i] = dist
     return dists
-    
+
 def binary_dist_jaccard(datamtx, strict=True):
     """Calculates jaccard distance between rows, returns distance matrix.
 
     converts matrix to boolean.  jaccard dist = 1 - jaccard index
-    
+
     see for example: wikipedia jaccard index (20 jan 2009)
     this is identical to a binary version of the soergel distance
 
@@ -1216,16 +1216,16 @@ def binary_dist_jaccard(datamtx, strict=True):
     b = num 1's in b
     c = num that are 1's in both a and b
     jaccard = 1 - (c/(a+b-c))
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -1248,7 +1248,7 @@ def binary_dist_jaccard(datamtx, strict=True):
     if numrows == 0 or numcols == 0:
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
-    
+
     rowsums = datamtx.sum(axis=1)
     for i in range(numrows):
         first = datamtx[i]
@@ -1269,7 +1269,7 @@ def binary_dist_lennon(datamtx, strict=True):
 
     converts matrix to boolean.  jaccard dist = 1 - lennon similarity
     lennon's similarity is a modification of simpson's index
-    see Jack J.  Lennon, The geographical structure of British bird 
+    see Jack J.  Lennon, The geographical structure of British bird
     distributions: diversity, spatial turnover and scale
 
     Binary lennon:
@@ -1277,16 +1277,16 @@ def binary_dist_lennon(datamtx, strict=True):
     b = num 1's in b
     c = num that are 1's in both a and b
     lennon = 1 - (c/(c + min(a-c,b-c)))
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
     * two rows of all zeros returns 0 distance between them
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -1309,7 +1309,7 @@ def binary_dist_lennon(datamtx, strict=True):
     if numrows == 0 or numcols == 0:
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
-    
+
     rowsums = datamtx.sum(axis=1)
     for i in range(numrows):
         first = datamtx[i]
@@ -1330,7 +1330,7 @@ def binary_dist_lennon(datamtx, strict=True):
 def binary_dist_ochiai(datamtx, strict=True):
     """Calculates ochiai distance btw rows, returning distance matrix.
 
-    Note: Treats array as bool. 
+    Note: Treats array as bool.
     see for example:
     On the Mathematical Significance of the Similarity Index of Ochiai...
     Bolton, 1991
@@ -1339,9 +1339,9 @@ def binary_dist_ochiai(datamtx, strict=True):
     b = num 1's in b
     c = num that are 1's in both a and b
     ochiai = 1 - (c/sqrt(a*b))
-    
+
     * comparisons are between rows (samples)
-    * input: 2D numpy array.  Limited support for non-2D arrays if 
+    * input: 2D numpy array.  Limited support for non-2D arrays if
     strict==False
     * output: numpy 2D array float ('d') type.  shape (inputrows, inputrows)
     for sane input data
@@ -1349,7 +1349,7 @@ def binary_dist_ochiai(datamtx, strict=True):
     * an all zero row compared with a not all zero row returns a distance of 1
     * if strict==True, raises ValueError if any of the input data is negative,
     not finite, or if the input data is not a rank 2 array (a matrix).
-    * if strict==False, assumes input data is a matrix with nonnegative 
+    * if strict==False, assumes input data is a matrix with nonnegative
     entries.  If rank of input data is < 2, returns an empty 2d array (shape:
     (0, 0) ).  If 0 rows or 0 colunms, also returns an empty 2d array.
     """
@@ -1373,7 +1373,7 @@ def binary_dist_ochiai(datamtx, strict=True):
         return zeros((0,0),'d')
     dists = zeros((numrows,numrows),'d')
     rowsums = datamtx.sum(axis=1)
-    
+
     for i in range(numrows):
         first = datamtx[i]
         a = rowsums[i]
@@ -1389,7 +1389,7 @@ def binary_dist_ochiai(datamtx, strict=True):
                 dist = 1.0 - (c/sqrt(a*b))
             dists[i][j] = dists[j][i] = dist
     return dists
-    
+
 def binary_dist_pearson(datamtx, strict=True):
     """Calculates binary pearson distance between rows, returns distance matrix
 
@@ -1412,7 +1412,7 @@ if __name__ == "__main__":
                             [0,0,0,0],
                             [8,6,2,1],
                                     ])
-    
+
     res = dist_euclidean(matrix1)
     print "euclidean distance result: \n"
     print res

--- a/tests/test_maths/test_distance_transform.py
+++ b/tests/test_maths/test_distance_transform.py
@@ -5,8 +5,8 @@ from __future__ import division
 from cogent.util.unit_test import TestCase, main
 from cogent.maths.distance_transform import *
 from numpy import array, sqrt, shape, ones, diag
-            
-            
+
+
 __author__ = "Justin Kuczynski"
 __copyright__ = "Copyright 2007-2016, The Cogent Project"
 __contributors__ = ["Justin Kuczynski",
@@ -26,14 +26,14 @@ class functionTests(TestCase):
         self.mat_test = asmatrix([[10, 10, 20],
             [10, 15, 10],
             [15,  5,  5]], 'float')
-        
+
         self.emptyarray = array([], 'd')
         self.mtx1 = array([[1, 3],
                         [0.0, 23.1]],'d')
         self.dense1 = array([[1, 3],
                             [5, 2],
                             [0.1, 22]],'d')
-                        
+
         self.zeromtx = array([[ 0.0,  0.0,  0.0],
                             [ 0.0,  0.0 ,  0.0],
                             [ 0.0,  0.0,  0.0 ],
@@ -46,8 +46,8 @@ class functionTests(TestCase):
           [1,0,0,1],
           [0,0,3,0],
           [0,0,0,1]])
-                        
-    
+
+
     def get_sym_mtx_from_uptri(self, mtx):
         """helper fn, only for square matrices"""
         numrows, numcols = shape(mtx)
@@ -57,15 +57,15 @@ class functionTests(TestCase):
                     break
                 mtx[i,j] = mtx[j,i] # j < i, so row<col => upper triangle
         return mtx
- 
+
     def test_dist_canberra(self):
         """tests dist_canberra
-        
+
         tests inputs of empty mtx, zeros, and results compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(dist_canberra(self.zeromtx), zeros((4,4),'d'))
-        
+
         mtx1expected = array([[ 0.0,  46.2/52.2],
                     [ 46.2/52.2,  0.0 ]],'d')
         self.assertFloatEqual(dist_canberra(self.mtx1), mtx1expected)
@@ -78,27 +78,35 @@ class functionTests(TestCase):
         sparse1exp[0,1] = sparse1exp[1,0] = ( (5.33-.4) / (5.33 + .4) )
         self.assertFloatEqual(dist_canberra(self.sparse1), sparse1exp)
 
+    def test_dist_canberra_bug(self):
+        i = array([[0, 0, 1], [0, 1, 1]])
+        d = (1. / 2.) * sum([abs(0. - 1.) / (0. + 1.),
+                             abs(1. - 1.) / (1. + 1.)])
+        expected = array([[0.0, d], [d, 0.0]])
+        actual = dist_canberra(i)
+        self.assertFloatEqual(expected, actual)
+
     def test_dist_euclidean(self):
         """tests dist_euclidean
-        
+
         tests inputs of empty mtx, zeros, and dense1 compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(dist_euclidean(self.zeromtx), zeros((4,4),'d'))
-        
+
         dense1expected = array([[ 0.0,  sqrt(17.),  sqrt(.9**2 + 19**2)],
                             [ sqrt(17.),  0.0 ,  sqrt(4.9**2 + 20**2)],
                     [ sqrt(.9**2 + 19**2),  sqrt(4.9**2 + 20**2),  0.0 ]],'d')
-        self.assertFloatEqual(dist_euclidean(self.dense1), dense1expected)       
-    
+        self.assertFloatEqual(dist_euclidean(self.dense1), dense1expected)
+
     def test_dist_gower(self):
         """tests dist_gower
-        
+
         tests inputs of empty mtx, zeros, and results compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(dist_gower(self.zeromtx), zeros((4,4),'d'))
-        
+
         mtx1expected = array([[ 0.0,  2.],
                     [ 2.,  0.0 ]],'d')
         self.assertFloatEqual(dist_gower(self.mtx1), mtx1expected)
@@ -111,17 +119,17 @@ class functionTests(TestCase):
 
     def test_dist_manhattan(self):
         """tests dist_manhattan
-        
+
         tests inputs of empty mtx, zeros, and dense1 compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(dist_manhattan(self.zeromtx), zeros((4,4),'d'))
-        
+
         dense1expected = array([[ 0.0,  5.0,  019.9],
                             [ 5.0,  0.0 ,  24.9],
                             [ 19.9,  24.90,  0.0 ]],'d')
         self.assertFloatEqual(dist_manhattan(self.dense1), dense1expected)
-    
+
     def test_dist_abund_jaccard(self):
         """dist_abund_jaccard should compute distances for dense1 and mtx1"""
         mtx1_expected = array([[0, 0.25], [0.25, 0]], 'd')
@@ -136,17 +144,17 @@ class functionTests(TestCase):
             [1.0, 1.0, 0.0, 1.0],
             [1.0, 1.0, 1.0, 0.0]], 'd')
         self.assertEqual(dist_abund_jaccard(self.sparse1), sparse1_expected)
- 
+
     def test_dist_morisita_horn(self):
         """tests dist_morisita_horn
-        
+
         tests inputs of empty mtx, zeros, and dense1 compared with calcs done
         by hand"""
 
-        
+
         self.assertFloatEqual(dist_morisita_horn(self.zeromtx),
             zeros((4,4),'d'))
-        
+
         a = 1 - 2*69.3/(26/16. * 23.1 * 4)
         mtx1expected = array([[0, a],
                              [a,0]],'d')
@@ -155,94 +163,94 @@ class functionTests(TestCase):
 
     def test_dist_bray_curtis(self):
         """tests dist_bray_curtis
-        
+
         tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
         by hand"""
 
-        
+
         self.assertFloatEqual(dist_manhattan(self.zeromtx), zeros((4,4)*1,'d'))
-        
+
         mtx1expected = array([[0, 21.1/27.1],
                                 [21.1/27.1, 0]],'d')
         self.assertFloatEqual(dist_bray_curtis(self.mtx1), mtx1expected)
 
     def test_dist_bray_curtis_faith(self):
         """tests dist_bray_curtis_faith
-        
+
         tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
         by hand"""
 
-        
+
         self.assertFloatEqual(dist_manhattan(self.zeromtx), zeros((4,4)*1,'d'))
-        
+
         mtx1expected = array([[0, 21.1/27.1],
                                 [21.1/27.1, 0]],'d')
         self.assertFloatEqual(dist_bray_curtis_faith(self.mtx1), mtx1expected)
 
     def test_dist_soergel(self):
         """tests dist_soergel
-        
+
         tests inputs of empty mtx, zeros, and dense1 compared with calcs done
         by hand/manhattan dist"""
 
-        
+
         self.assertFloatEqual(dist_soergel(self.zeromtx), zeros((4,4)*1,'d'))
-          
+
         dense1expected = dist_manhattan(self.dense1)
         dense1norm = array([[ 1, 8, 23],
                             [8,1,27],
                             [23,27,1]],'d')
         dense1expected /= dense1norm
-        
+
         self.assertFloatEqual(dist_soergel(self.dense1), dense1expected)
-    
+
     def test_dist_kulczynski(self):
         """tests dist_kulczynski
-        
+
         tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
         by hand"""
 
-        
+
         self.assertFloatEqual(dist_kulczynski(self.zeromtx),
             zeros((4,4)*1,'d'))
-        
+
         mtx1expected = array([[0, 1.-1./2.*(3./4. + 3./23.1)],
                                 [1.-1./2.*(3./4. + 3./23.1), 0]],'d')
-                                
+
         self.assertFloatEqual(dist_kulczynski(self.mtx1), mtx1expected)
-            
+
     def test_dist_pearson(self):
         """tests dist_pearson
-        
+
         tests inputs of empty mtx, zeros, mtx compared with calcs done
-        by hand, and an example from 
+        by hand, and an example from
         http://davidmlane.com/hyperstat/A56626.html
         """
-        
+
         self.assertFloatEqual(dist_pearson(self.zeromtx), zeros((4,4),'d'))
-        
+
         mtx1expected = array([[0, 0],
                             [0, 0]],'d')
         self.assertFloatEqual(dist_pearson(self.mtx1), mtx1expected)
-        
+
         # example 1 from http://davidmlane.com/hyperstat/A56626.html
         ex1 = array([[1, 2, 3, ],
                         [2,5,6]],'d')
         ex1res = 1 - 4./sqrt(2.*(8+2./3.))
         ex1expected = array([[0, ex1res],
                             [ex1res, 0]],'d')
-        
+
         self.assertFloatEqual(dist_pearson(ex1), ex1expected)
-        
+
     def test_dist_spearman_approx(self):
         """tests dist_spearman_approx
-        
+
         tests inputs of empty mtx, zeros, and an example from wikipedia
         """
-    
+
         self.assertFloatEqual(dist_spearman_approx(self.zeromtx),
             zeros((4,4)*1,'d'))
-        
+
         # ex1 from wikipedia Spearman's_rank_correlation_coefficient 20jan2009
         ex1 = array([[106 ,86 ,100 ,101 ,99 ,103 ,97 ,113 ,112 ,110],
                     [7,0,27,50,28,29,20,12,6,17]],'d')
@@ -250,7 +258,7 @@ class functionTests(TestCase):
         ex1expected = array([[0, ex1res],
                             [ex1res, 0]],'d')
         self.assertFloatEqual(dist_spearman_approx(ex1), ex1expected)
-    
+
     # now binary fns
     def test_binary_dist_otu_gain(self):
         """ binary OTU gain functions as expected """
@@ -263,10 +271,10 @@ class functionTests(TestCase):
 
     def test_binary_dist_chisq(self):
         """tests binary_dist_chisq
-        
+
         tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(binary_dist_chisq(self.zeromtx),
             zeros((4,4),'d'))
 
@@ -277,11 +285,11 @@ class functionTests(TestCase):
 
     def test_binary_dist_chord(self):
         """tests binary_dist_chord
-        
+
         tests inputs of empty mtx, zeros, and results compared with calcs done
         by hand"""
 
-        
+
         self.assertFloatEqual(binary_dist_chord(self.zeromtx),
             zeros((4,4),'d'))
 
@@ -289,15 +297,15 @@ class functionTests(TestCase):
                                [ sqrt( 1/2. + (1./sqrt(2.) -1.)**2),0]],'d')
         self.assertFloatEqual(binary_dist_chord(self.mtx1),
             mtx1expected)
-           
+
 
     def test_binary_dist_lennon(self):
         """tests binary_dist_lennon
-        
+
         tests inputs of empty mtx, zeros, and results compared with calcs done
         by hand"""
 
-        
+
         self.assertFloatEqual(binary_dist_lennon(self.zeromtx),
             zeros((4,4),'d'))
 
@@ -306,7 +314,7 @@ class functionTests(TestCase):
                         [0,0.0,8233.1]],'d')
         self.assertFloatEqual(binary_dist_lennon(mtxa),
             zeros((3,3),'d') )
-        
+
         mtxb = array([[5.2,0,0.2, 9.2],
                         [0,0,0,1],
                         [0,3.2,0,8233.1]],'d')
@@ -318,25 +326,25 @@ class functionTests(TestCase):
 
     def test_binary_dist_pearson(self):
         """tests binary_dist_pearson
-        
+
         tests inputs of empty mtx, zeros, and dense1 compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(binary_dist_pearson(self.zeromtx),
             zeros((4,4),'d'))
-    
+
         self.assertFloatEqual(binary_dist_pearson(self.dense1), zeros((3,3)))
 
-              
+
     def test_binary_dist_jaccard(self):
         """tests binary_dist_jaccard
-        
+
         tests inputs of empty mtx, zeros, and sparse1 compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(binary_dist_jaccard(self.zeromtx),
             zeros((4,4),'d'))
-        
+
         sparse1expected = array([[0, 0, 1., 1.],
                                 [0, 0, 1, 1],
                                 [1,1,0,1],
@@ -355,56 +363,56 @@ class functionTests(TestCase):
 
     def test_binary_dist_ochiai(self):
         """tests binary_dist_ochiai
-        
+
         tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
         by hand"""
-        
+
         self.assertFloatEqual(binary_dist_ochiai(self.zeromtx),
             zeros((4,4),'d'))
-            
+
         mtx1expected = array([[0,1-1/sqrt(2.)],
                     [1-1/sqrt(2.), 0,]],'d')
         self.assertFloatEqual(binary_dist_ochiai(self.mtx1),mtx1expected)
-        
+
     def test_binary_dist_hamming(self):
         """tests binary_dist_hamming
-        
+
         tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
-        by hand"""        
-        
+        by hand"""
+
         self.assertFloatEqual(binary_dist_hamming(self.zeromtx),
             zeros((4,4),'d'))
-        
+
         mtx1expected = array([[0,1],
                             [1, 0,]],'d')
         self.assertFloatEqual(binary_dist_hamming(self.mtx1),mtx1expected)
-        
+
     def test_binary_dist_sorensen_dice(self):
         """tests binary_dist_sorensen_dice
-        
-        tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
-        by hand""" 
 
-        
+        tests inputs of empty mtx, zeros, and mtx1 compared with calcs done
+        by hand"""
+
+
         self.assertFloatEqual(binary_dist_sorensen_dice(self.zeromtx),
             zeros((4,4),'d'))
-            
+
         mtx1expected = array([[0,1/3.],
                             [1/3., 0,]],'d')
         self.assertFloatEqual(binary_dist_sorensen_dice(self.mtx1),
             mtx1expected)
-        
+
         sparse1expected = array([[0, 0, 1., 1.],
                                 [0, 0, 1, 1],
                                 [1,1,0,1],
-                                [1,1,1,0]],'d') 
-        
+                                [1,1,1,0]],'d')
+
         self.assertFloatEqual(binary_dist_sorensen_dice(self.sparse1),
             sparse1expected)
 
     def test_binary_dist_euclidean(self):
         """tests binary_dist_euclidean
-        
+
         tests two inputs compared with calculations by hand, and runs zeros
         and an empty input"""
         dense1expected = array([[ 0.0,  0.0,  0.0],
@@ -417,19 +425,19 @@ class functionTests(TestCase):
         sparse1expected[1,3] = 1.0
         sparse1expected[2,3] = 1.0
         sparse1expected = self.get_sym_mtx_from_uptri(sparse1expected)
-                    
+
         self.assertFloatEqual(binary_dist_euclidean(self.dense1),
             dense1expected)
         self.assertFloatEqual(binary_dist_euclidean(self.sparse1),
             sparse1expected)
         self.assertFloatEqual(binary_dist_euclidean(self.zeromtx),
             zeros((4,4),'d'))
-    
+
 
     #zj's stuff
     def test_chord_transform(self):
         """trans_chord should return the exp result in the ref paper."""
-        
+
         exp =  [[ 0.40824829,  0.40824829,  0.81649658],
                 [ 0.48507125,  0.72760688,  0.48507125],
                 [ 0.90453403,  0.30151134,  0.30151134]]
@@ -438,9 +446,9 @@ class functionTests(TestCase):
 
     def test_chord_dist(self):
         """dist_chord should return the exp result."""
-        
+
         self.assertFloatEqual(dist_chord(self.zeromtx), zeros((4,4),'d'))
-        
+
         exp =  [[ 0.        ,  0.46662021,  0.72311971],
                 [ 0.46662021,  0.        ,  0.62546036],
                 [ 0.72311971,  0.62546036,  0.        ]]
@@ -457,9 +465,9 @@ class functionTests(TestCase):
 
     def test_chisq_distance(self):
         """dist_chisq should return the exp result."""
-        
+
         self.assertFloatEqual(dist_chisq(self.zeromtx), zeros((4,4),'d'))
-        
+
         exp_d = [[ 0.        ,  0.4910521 ,  0.78452291],
                 [ 0.4910521 ,  0.        ,  0.69091002],
                 [ 0.78452291,  0.69091002,  0.        ]]
@@ -476,9 +484,9 @@ class functionTests(TestCase):
 
     def test_hellinger_distance(self):
         """dist_hellinger should return the exp result."""
-        
+
         self.assertFloatEqual(dist_hellinger(self.zeromtx), zeros((4,4),'d'))
-                
+
         exp =  [[ 0.        ,  0.23429661,  0.38175149],
                 [ 0.23429661,  0.        ,  0.32907422],
                 [ 0.38175149,  0.32907422,  0.        ]]
@@ -495,9 +503,9 @@ class functionTests(TestCase):
 
     def test_species_profile_distance(self):
         """dist_specprof should return the exp result."""
-        
+
         self.assertFloatEqual(dist_specprof(self.zeromtx), zeros((4,4),'d'))
-        
+
         exp = [[ 0.        ,  0.28121457,  0.46368092],
                [ 0.28121457,  0.        ,  0.39795395],
                [ 0.46368092,  0.39795395,  0.        ]]
@@ -516,7 +524,7 @@ class functionTests(TestCase):
                         [0,0,1],
                         [1,1,0],
                         ]))
-        
+
 
     def test_dist_bray_curtis_magurran2(self):
         """ should match hand-calculated values"""
@@ -530,13 +538,13 @@ class functionTests(TestCase):
                         [1-14/17,0,1-4/11],
                         [1-.4,1-4/11,0],
                         ]))
-    
+
     #def test_no_dupes(self):
-        #""" here we check all distance functions in distance_transform for 
+        #""" here we check all distance functions in distance_transform for
         #duplicate
-        #results.  Uses an unsafe hack to get all distance functions, 
+        #results.  Uses an unsafe hack to get all distance functions,
         #thus disabled by default
-        #The dataset is from Legendre 2001, Ecologically Meaningful... 
+        #The dataset is from Legendre 2001, Ecologically Meaningful...
         #also, doesn't actually raise an error on failing, just prints to
         #stdout
         #"""
@@ -562,14 +570,14 @@ class functionTests(TestCase):
         #[0,0,0,4,2,0,0,0,4],
         #[0,0,0,2,4,0,0,0,1],
         #[0,0,0,1,7,0,0,0,0]], 'd')
-        
+
         #distfns = []
         #distfn_strs = dir(distance_transform)
         ## warning: dangerous eval, and might catch bad or not functions
         #for fnstr in distfn_strs:
             #if fnstr.find('dist') != -1:
                 #distfns.append(eval('%s' % fnstr))
-        
+
         #dist_results = []
         #for distfn in distfns:
             #dist_results.append(distfn(L19data))


### PR DESCRIPTION
This pull request fixes a slight bug in the Canberra calculation in PyCogent, and also fixes the name of the method (in the docstring). Specifically, the existing was miscalculating the number of nonzero elements used, resulting in an overestimation of the scaling factor.

Co-authors on this include: @gregcaporaso @antgonza @ElDeveloper @rob-knight and @justin212k following internal discussion. This issue was first noticed due to a discrepancy in the calculations between QIIME1 and QIIME2, which was first identified by Dr. Alexey Melnik.