### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
Add pyproject.toml. Newer versions of pip can handle installing the build dependencies (numpy) in a separate transaction. See [PEP-518](https://www.python.org/dev/peps/pep-0518/)